### PR TITLE
fix for table initial state

### DIFF
--- a/src/Table/Providers.js
+++ b/src/Table/Providers.js
@@ -75,11 +75,20 @@ export const TableSearchProvider = ({
 
   const trigger = stateHandler(rowsQuery.mutate, sort);
 
-  if (initialValues) {
-    Object.assign(initialState, { filter: { ...initialState.filter, ...initialValues } });
-  }
+  const initialStateWithValues = {
+    ...initialState,
+    filter: {
+      ...initialState.filter,
+      ...(initialValues || {}),
+    },
+  };
 
-  const state = useUrlState(urlStateKey, initialState, trigger, noUrlState);
+  const state = useUrlState(
+    urlStateKey,
+    initialStateWithValues,
+    trigger,
+    noUrlState,
+  );
 
   const downloadPayload = (page, size) => payload({
     ...state.current,


### PR DESCRIPTION
Don't object.assign initial values to state, use a spread copy when passing to useUrlState instead, otherwise the initial state state persists to other pages too